### PR TITLE
Parallel batch tag upsert

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,9 +116,9 @@ dependencies {
     compile 'javax.validation:validation-api:2.0.1.Final'
 
     testCompile 'org.apache.httpcomponents:httpclient:4.5.6'
-    testCompile('org.junit.jupiter:junit-jupiter-api:5.3.1')
-    testCompile('org.junit.jupiter:junit-jupiter-params:5.3.1')
-    testRuntime('org.junit.jupiter:junit-jupiter-engine:5.3.1')
+    testCompile 'org.junit.jupiter:junit-jupiter-api:5.3.1'
+    testCompile 'org.junit.jupiter:junit-jupiter-params:5.3.1'
+    testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
     testCompile 'org.mockito:mockito-core:2.22.0'
     testCompile 'org.assertj:assertj-core:3.11.1'
     testCompile 'io.github.benas:random-beans:3.7.0'

--- a/src/main/java/io/wisetime/connector/ServerRunner.java
+++ b/src/main/java/io/wisetime/connector/ServerRunner.java
@@ -33,6 +33,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.ConsoleAppender;
 import io.wisetime.connector.api_client.ApiClient;
 import io.wisetime.connector.api_client.DefaultApiClient;
+import io.wisetime.connector.api_client.support.RestRequestExecutor;
 import io.wisetime.connector.config.ConnectorConfigKey;
 import io.wisetime.connector.config.RuntimeConfig;
 import io.wisetime.connector.datastore.FileStore;
@@ -138,7 +139,8 @@ public class ServerRunner {
           throw new IllegalArgumentException(
               "an apiKey must be supplied via constructor or environment parameter to use the default apiClient");
         }
-        apiClient = new DefaultApiClient();
+        RestRequestExecutor requestExecutor = new RestRequestExecutor(apiKey);
+        apiClient = new DefaultApiClient(requestExecutor);
       }
 
       if (wiseTimeConnector == null) {

--- a/src/main/java/io/wisetime/connector/api_client/ApiClient.java
+++ b/src/main/java/io/wisetime/connector/api_client/ApiClient.java
@@ -8,14 +8,10 @@ import java.io.IOException;
 import java.util.List;
 
 import io.wisetime.generated.connect.AddKeywordsRequest;
-import io.wisetime.generated.connect.AddKeywordsResponse;
-import io.wisetime.generated.connect.DeleteKeywordResponse;
-import io.wisetime.generated.connect.DeleteTagResponse;
 import io.wisetime.generated.connect.SubscribeRequest;
 import io.wisetime.generated.connect.SubscribeResult;
 import io.wisetime.generated.connect.TeamInfoResult;
 import io.wisetime.generated.connect.UpsertTagRequest;
-import io.wisetime.generated.connect.UpsertTagResponse;
 
 /**
  * @author thomas.haines@practiceinsight.io
@@ -26,10 +22,9 @@ public interface ApiClient {
    * Create a new tag, or update the tag if it already exists.
    *
    * @param upsertTagRequest information about the tag to be upserted
-   * @return result of the tag upsert operation
    * @throws IOException
    */
-  UpsertTagResponse tagUpsert(UpsertTagRequest upsertTagRequest) throws IOException;
+  void tagUpsert(UpsertTagRequest upsertTagRequest) throws IOException;
 
   /**
    * Upsert a batch of tags. Use this method if you have a large number of tags to upsert.
@@ -45,30 +40,28 @@ public interface ApiClient {
    * Delete an existing tag.
    *
    * @param tagName the name of the tag to delete
-   * @return result of the tag deletion operation
    * @throws IOException
    */
-  DeleteTagResponse tagDelete(String tagName) throws IOException;
+  void tagDelete(String tagName) throws IOException;
 
   /**
    * Add keywords to a tag. Existing keywords not be overwritten.
    *
    * @param tagName the tag to which to add the keywords
    * @param addKeywordsRequest request contains list of keywords to be added
-   * @return result of the add keywords operation
    * @throws IOException
    */
-  AddKeywordsResponse tagAddKeywords(String tagName, AddKeywordsRequest addKeywordsRequest) throws IOException;
+  void tagAddKeywords(String tagName, AddKeywordsRequest addKeywordsRequest) throws IOException;
 
   /**
-   * Delete keyword from a tag
+   * Delete keyword from a tag.
    *
    * @param tagName the tag whose keyword we want to delete
    * @param keyword the keyword to be deleted
    * @return result of the keyword delete operation
    * @throws IOException
    */
-  DeleteKeywordResponse tagDeleteKeyword(String tagName, String keyword) throws IOException;
+  void tagDeleteKeyword(String tagName, String keyword) throws IOException;
 
   /**
    * Get the details for the team linked to the API key making the request.
@@ -78,5 +71,13 @@ public interface ApiClient {
    */
   TeamInfoResult teamInfo() throws IOException;
 
+  /**
+   * Subscribes a new webhook for receiving posted time. WiseTime will call your webhook whenever
+   * a user posts time to your team.
+   *
+   * @param subscribeRequest information about the webhook to be created
+   * @return the subscription result will contain the webhook ID that was assigned to the new webhook
+   * @throws IOException
+   */
   SubscribeResult postedTimeSubscribe(SubscribeRequest subscribeRequest) throws IOException;
 }

--- a/src/main/java/io/wisetime/connector/api_client/ApiClient.java
+++ b/src/main/java/io/wisetime/connector/api_client/ApiClient.java
@@ -5,6 +5,7 @@
 package io.wisetime.connector.api_client;
 
 import java.io.IOException;
+import java.util.List;
 
 import io.wisetime.generated.connect.DeleteTagResponse;
 import io.wisetime.generated.connect.TeamInfoResult;
@@ -18,14 +19,37 @@ public interface ApiClient {
 
   /**
    * Create a new tag, or update the tag if it already exists.
+   *
+   * @param upsertTagRequest information about the tag to be upserted
+   * @return result of the tag upsert operation
+   * @throws IOException
    */
   UpsertTagResponse tagUpsert(UpsertTagRequest upsertTagRequest) throws IOException;
 
   /**
-   * Delete an existing tag
+   * Upsert a batch of tags. Use this method if you have a large number of tags to upsert.
+   * Blocks until completion or throws an IOException on the first error.
+   * It is safe to retry on error since tag upsert is idempotent.
+   *
+   * @param upsertTagRequests request list of tags to be upserted
+   * @throws IOException
+   */
+  void tagUpsertBatch(List<UpsertTagRequest> upsertTagRequests) throws IOException;
+
+  /**
+   * Delete an existing tag.
+   *
+   * @param tagName the name of the tag to delete
+   * @return result of the tag deletion operation
+   * @throws IOException
    */
   DeleteTagResponse tagDelete(String tagName) throws IOException;
 
-
+  /**
+   * Get the details for the team linked to the API key making the request.
+   *
+   * @return the team information
+   * @throws IOException
+   */
   TeamInfoResult teamInfo() throws IOException;
 }

--- a/src/main/java/io/wisetime/connector/api_client/DefaultApiClient.java
+++ b/src/main/java/io/wisetime/connector/api_client/DefaultApiClient.java
@@ -60,10 +60,8 @@ public class DefaultApiClient implements ApiClient {
         .map(request -> {
           try {
             tagUpsert(request);
-            log.info("Success: " + request.getName());
             return Optional.<Exception>empty();
           } catch (Exception e) {
-            log.info("Failed: " + request.getName());
             return Optional.of(e);
           }
         })

--- a/src/main/java/io/wisetime/connector/api_client/DefaultApiClient.java
+++ b/src/main/java/io/wisetime/connector/api_client/DefaultApiClient.java
@@ -6,44 +6,36 @@ package io.wisetime.connector.api_client;
 
 import com.google.common.collect.Lists;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.http.message.BasicHeader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ForkJoinPool;
 
 import io.wisetime.connector.api_client.support.RestRequestExecutor;
-import io.wisetime.connector.config.ConnectorConfigKey;
-import io.wisetime.connector.config.RuntimeConfig;
 import io.wisetime.generated.connect.DeleteTagResponse;
 import io.wisetime.generated.connect.TeamInfoResult;
 import io.wisetime.generated.connect.UpsertTagRequest;
 import io.wisetime.generated.connect.UpsertTagResponse;
 
+import static java.util.Optional.empty;
+
 /**
  * @author thomas.haines@practiceinsight.io
+ * @author shane.xie@practiceinsight.io
  */
 public class DefaultApiClient implements ApiClient {
 
   private static final Logger log = LoggerFactory.getLogger(DefaultApiClient.class);
-  private final RestRequestExecutor restRequestExecutor;
+  private RestRequestExecutor restRequestExecutor;
 
-  public DefaultApiClient(String apiKey) {
-    if (StringUtils.isEmpty(apiKey)) {
-      String errorMsg = "No api key defined";
-      log.error(errorMsg);
-      throw new RuntimeException(errorMsg);
-    }
-    restRequestExecutor = new RestRequestExecutor(apiKey);
-  }
-
-  /**
-   * Blank constructor assumes that the {@see io.wisetime.connector.config.ConnectorConfigKey.API_KEY} variable is provided
-   * via an environment variable or system property.
-   */
-  public DefaultApiClient() {
-    this(RuntimeConfig.findString(ConnectorConfigKey.API_KEY).orElse(""));
+  public DefaultApiClient(RestRequestExecutor restRequestExecutor) {
+    this.restRequestExecutor = restRequestExecutor;
   }
 
   @Override
@@ -53,6 +45,50 @@ public class DefaultApiClient implements ApiClient {
         EndpointPath.TagUpsert,
         upsertTagRequest
     );
+  }
+
+  /**
+   * This implementation upserts the batch of tags in parallel.
+   * It stops if an error is encountered while upserting tags.
+   */
+  @Override
+  public void tagUpsertBatch(List<UpsertTagRequest> upsertTagRequests) throws IOException {
+
+    final Callable<Optional<Exception>> parallelUntilError = () -> upsertTagRequests
+        .parallelStream()
+        // Wrap any exception with an Optional so we can short circuit the stream on error
+        .map(request -> {
+          try {
+            tagUpsert(request);
+            log.info("Success: " + request.getName());
+            return Optional.<Exception>empty();
+          } catch (Exception e) {
+            log.info("Failed: " + request.getName());
+            return Optional.of(e);
+          }
+        })
+        .filter(Optional::isPresent)
+        .findFirst()
+        .orElse(empty());
+
+    ForkJoinPool forkJoinPool = null;
+    Optional<Exception> error;
+
+    try {
+      // Use a ForkJoinPool to control parallelism
+      forkJoinPool = new ForkJoinPool(10);
+      error = forkJoinPool.submit(parallelUntilError).get();
+    } catch (InterruptedException | ExecutionException e) {
+      // Tidy up so client code only needs to deal with one type of exception
+      throw new IOException(e);
+    } finally {
+      if (forkJoinPool != null) {
+        forkJoinPool.shutdown();
+      }
+    }
+    if (error.isPresent()) {
+      throw new IOException("Failed to complete tag upsert batch. Stopped at first error. ", error.get());
+    }
   }
 
   @Override

--- a/src/main/java/io/wisetime/connector/api_client/DefaultApiClient.java
+++ b/src/main/java/io/wisetime/connector/api_client/DefaultApiClient.java
@@ -46,8 +46,8 @@ public class DefaultApiClient implements ApiClient {
   }
 
   @Override
-  public UpsertTagResponse tagUpsert(UpsertTagRequest upsertTagRequest) throws IOException {
-    return restRequestExecutor.executeTypedBodyRequest(
+  public void tagUpsert(UpsertTagRequest upsertTagRequest) throws IOException {
+    restRequestExecutor.executeTypedBodyRequest(
         UpsertTagResponse.class,
         EndpointPath.TagUpsert,
         upsertTagRequest
@@ -92,8 +92,8 @@ public class DefaultApiClient implements ApiClient {
   }
 
   @Override
-  public DeleteTagResponse tagDelete(String tagName) throws IOException {
-    return restRequestExecutor.executeTypedRequest(
+  public void tagDelete(String tagName) throws IOException {
+    restRequestExecutor.executeTypedRequest(
         DeleteTagResponse.class,
         EndpointPath.TagDelete,
         Lists.newArrayList(new BasicNameValuePair("tagName", tagName))
@@ -101,8 +101,8 @@ public class DefaultApiClient implements ApiClient {
   }
 
   @Override
-  public AddKeywordsResponse tagAddKeywords(String tagName, AddKeywordsRequest addKeywordsRequest) throws IOException {
-    return restRequestExecutor.executeTypedBodyRequest(
+  public void tagAddKeywords(String tagName, AddKeywordsRequest addKeywordsRequest) throws IOException {
+    restRequestExecutor.executeTypedBodyRequest(
         AddKeywordsResponse.class,
         EndpointPath.TagAddKeyword,
         Lists.newArrayList(new BasicNameValuePair("tagName", tagName)),
@@ -111,8 +111,8 @@ public class DefaultApiClient implements ApiClient {
   }
 
   @Override
-  public DeleteKeywordResponse tagDeleteKeyword(String tagName, String keyword) throws IOException {
-    return restRequestExecutor.executeTypedRequest(
+  public void tagDeleteKeyword(String tagName, String keyword) throws IOException {
+    restRequestExecutor.executeTypedRequest(
         DeleteKeywordResponse.class,
         EndpointPath.TagDeleteKeyword,
         Lists.newArrayList(

--- a/src/test/java/io/wisetime/connector/api_client/DefaultApiClientIntegrationTest.java
+++ b/src/test/java/io/wisetime/connector/api_client/DefaultApiClientIntegrationTest.java
@@ -19,14 +19,10 @@ import io.wisetime.connector.api_client.support.RestRequestExecutor;
 import io.wisetime.connector.config.ConnectorConfigKey;
 import io.wisetime.connector.config.RuntimeConfig;
 import io.wisetime.generated.connect.AddKeywordsRequest;
-import io.wisetime.generated.connect.AddKeywordsResponse;
-import io.wisetime.generated.connect.DeleteKeywordResponse;
-import io.wisetime.generated.connect.DeleteTagResponse;
 import io.wisetime.generated.connect.SubscribeRequest;
 import io.wisetime.generated.connect.SubscribeResult;
 import io.wisetime.generated.connect.TeamInfoResult;
 import io.wisetime.generated.connect.UpsertTagRequest;
-import io.wisetime.generated.connect.UpsertTagResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -76,8 +72,7 @@ class DefaultApiClientIntegrationTest {
     request.setDescription("Tag from API");
     request.setPath("/");
     request.setAdditionalKeywords(Lists.newArrayList("ViaCreatedApi"));
-    UpsertTagResponse response = defaultApiClient.tagUpsert(request);
-    log.info("UpsertTagResponse={}", response.toString());
+    defaultApiClient.tagUpsert(request);
   }
 
   @Test
@@ -90,8 +85,7 @@ class DefaultApiClientIntegrationTest {
     request.setDescription("Tag from API");
     request.setPath("/");
     request.setAdditionalKeywords(Lists.newArrayList("CreatedViaApi with space"));
-    UpsertTagResponse response = defaultApiClient.tagUpsert(request);
-    log.info("UpsertTagResponse={}", response.toString());
+    defaultApiClient.tagUpsert(request);
   }
 
   @Test
@@ -99,8 +93,7 @@ class DefaultApiClientIntegrationTest {
     if (defaultApiClient == null) {
       return;
     }
-    DeleteTagResponse response = defaultApiClient.tagDelete("Management");
-    log.info(response.toString());
+    defaultApiClient.tagDelete("Management");
     defaultApiClient.tagDelete("Shared-1439");
   }
 
@@ -111,8 +104,7 @@ class DefaultApiClientIntegrationTest {
     }
     AddKeywordsRequest request = new AddKeywordsRequest();
     request.setAdditionalKeywords(ImmutableList.of("keyword_from_API", "keyword with space"));
-    AddKeywordsResponse response = defaultApiClient.tagAddKeywords("CreatedViaApi", request);
-    log.info(response.toString());
+    defaultApiClient.tagAddKeywords("CreatedViaApi", request);
   }
 
   @Test
@@ -120,11 +112,8 @@ class DefaultApiClientIntegrationTest {
     if (defaultApiClient == null) {
       return;
     }
-    DeleteKeywordResponse response = defaultApiClient.tagDeleteKeyword("CreatedViaApi", "keyword_from_API");
-    log.info(response.toString());
-
-    response = defaultApiClient.tagDeleteKeyword("CreatedViaApi", "keyword with space");
-    log.info(response.toString());
+    defaultApiClient.tagDeleteKeyword("CreatedViaApi", "keyword_from_API");
+    defaultApiClient.tagDeleteKeyword("CreatedViaApi", "keyword with space");
   }
 
   @Test

--- a/src/test/java/io/wisetime/connector/api_client/DefaultApiClientIntegrationTest.java
+++ b/src/test/java/io/wisetime/connector/api_client/DefaultApiClientIntegrationTest.java
@@ -12,7 +12,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Optional;
 
+import io.wisetime.connector.api_client.support.RestRequestExecutor;
 import io.wisetime.connector.config.ConnectorConfigKey;
 import io.wisetime.connector.config.RuntimeConfig;
 import io.wisetime.generated.connect.DeleteTagResponse;
@@ -36,13 +38,15 @@ class DefaultApiClientIntegrationTest {
 
   @BeforeAll
   static void setup() {
-    boolean runnable = RuntimeConfig.findString(ConnectorConfigKey.API_KEY).isPresent()
+    Optional<String> apiKey = RuntimeConfig.findString(ConnectorConfigKey.API_KEY);
+    boolean runnable = apiKey.isPresent()
         && !RuntimeConfig.findString(ConnectorConfigKey.API_BASE_URL).orElse("").contains("wisetime.io");
     if (!runnable) {
       log.info("DefaultApiClientIntegrationTest skipped");
       return;
     }
-    defaultApiClient = new DefaultApiClient();
+    RestRequestExecutor requestExecutor = new RestRequestExecutor(apiKey.get());
+    defaultApiClient = new DefaultApiClient(requestExecutor);
   }
 
   @Test

--- a/src/test/java/io/wisetime/connector/api_client/DefaultApiClientTest.java
+++ b/src/test/java/io/wisetime/connector/api_client/DefaultApiClientTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2018 Practice Insight Pty Ltd. All Rights Reserved.
+ */
+
+package io.wisetime.connector.api_client;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import io.wisetime.connector.api_client.support.RestRequestExecutor;
+import io.wisetime.generated.connect.UpsertTagRequest;
+import io.wisetime.generated.connect.UpsertTagResponse;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.atMost;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+/**
+ * @author shane.xie@practiceinsight.io
+ */
+public class DefaultApiClientTest {
+
+  private RestRequestExecutor requestExecutor;
+  private DefaultApiClient apiClient;
+
+  @BeforeEach
+  void init() {
+    requestExecutor = mock(RestRequestExecutor.class);
+    apiClient = new DefaultApiClient(requestExecutor);
+  }
+
+  @Test
+  void tagUpsertBatch_completes_on_no_error() throws IOException {
+    when(requestExecutor.executeTypedBodyRequest(any(), any(), any()))
+        .thenReturn(new UpsertTagResponse());
+
+    apiClient.tagUpsertBatch(fakeUpsertTagRequests(5));
+
+    verify(requestExecutor, times(5)).executeTypedBodyRequest(
+        any(),
+        any(EndpointPath.TagUpsert.getClass()),
+        any(UpsertTagRequest.class)
+    );
+  }
+
+  @Test
+  void tagUpsertBatch_stops_on_error() throws IOException {
+    when(requestExecutor.executeTypedBodyRequest(any(), any(), any()))
+        .thenReturn(new UpsertTagResponse())
+        .thenThrow(new IOException());
+
+    assertThatExceptionOfType(IOException.class).isThrownBy(() ->
+        apiClient.tagUpsertBatch(fakeUpsertTagRequests(1000))
+    );
+
+    // At least 10 requests made in parallel before we notice an error.
+    verify(requestExecutor, atLeast(10)).executeTypedBodyRequest(
+        any(),
+        any(EndpointPath.TagUpsert.getClass()),
+        any(UpsertTagRequest.class)
+    );
+
+    // We should notice that a request has failed way before we reach the end of the list
+    verify(requestExecutor, atMost(20)).executeTypedBodyRequest(
+        any(),
+        any(EndpointPath.TagUpsert.getClass()),
+        any(UpsertTagRequest.class)
+    );
+  }
+
+  @Test
+  void tagUpsertBatch_wraps_exceptions() throws IOException {
+    when(requestExecutor.executeTypedBodyRequest(any(), any(), any()))
+        .thenThrow(new RuntimeException());
+
+    assertThatExceptionOfType(IOException.class).isThrownBy(() ->
+        apiClient.tagUpsertBatch(fakeUpsertTagRequests(3))
+    );
+  }
+
+  private List<UpsertTagRequest> fakeUpsertTagRequests(final int numberOfRequests) {
+    final ArrayList<UpsertTagRequest> requests = new ArrayList<>();
+    IntStream
+        .range(1, numberOfRequests + 1)
+        .forEach(i -> requests.add(new UpsertTagRequest().name(String.valueOf(i))));
+    return requests;
+  }
+}


### PR DESCRIPTION
Implement batch tag upserts. This will be especially useful for initial tag uploads, and is optimised for uploading large batches.