### PR TITLE
Add utility for unit tests to encapsulate rebuild step

### DIFF
--- a/src/main/java/io/wisetime/connector/config/RuntimeConfig.java
+++ b/src/main/java/io/wisetime/connector/config/RuntimeConfig.java
@@ -86,6 +86,16 @@ public class RuntimeConfig {
     return INSTANCE.getString(configKey.getConfigKey());
   }
 
+  public static void setProperty(RuntimeConfigKey configKey, String value) {
+    System.setProperty(configKey.getConfigKey(), value);
+    rebuild();
+  }
+
+  public static void clearProperty(RuntimeConfigKey configKey) {
+    System.clearProperty(configKey.getConfigKey());
+    rebuild();
+  }
+
   @VisibleForTesting
   public static void rebuild() {
     INSTANCE = new RuntimeConfig();

--- a/src/test/java/io/wisetime/connector/config/RuntimeConfigTest.java
+++ b/src/test/java/io/wisetime/connector/config/RuntimeConfigTest.java
@@ -47,7 +47,7 @@ public class RuntimeConfigTest {
     FileUtils.writeStringToFile(propertyFile, fileContent.toString(), StandardCharsets.UTF_8);
 
     try {
-      System.setProperty(CONNECTOR_PROPERTIES_FILE.getConfigKey(), propertyFile.getPath());
+      RuntimeConfig.setProperty(CONNECTOR_PROPERTIES_FILE, propertyFile.getPath());
       RuntimeConfig.rebuild();
 
       assertThat(RuntimeConfig.getString(() -> keyA))
@@ -57,8 +57,7 @@ public class RuntimeConfigTest {
           .contains(valueB);
 
     } finally {
-      System.clearProperty(CONNECTOR_PROPERTIES_FILE.getConfigKey());
-      RuntimeConfig.rebuild();
+      RuntimeConfig.clearProperty(CONNECTOR_PROPERTIES_FILE);
     }
 
     assertThat(RuntimeConfig.getString(() -> keyB))

--- a/src/test/java/io/wisetime/connector/config/RuntimeConfigTest.java
+++ b/src/test/java/io/wisetime/connector/config/RuntimeConfigTest.java
@@ -48,7 +48,6 @@ public class RuntimeConfigTest {
 
     try {
       RuntimeConfig.setProperty(CONNECTOR_PROPERTIES_FILE, propertyFile.getPath());
-      RuntimeConfig.rebuild();
 
       assertThat(RuntimeConfig.getString(() -> keyA))
           .contains(valueA);


### PR DESCRIPTION
Add utility for unit tests to encapsulate rebuild step.  As discussed, to simplify state management of config values in unit testing.