### PR TITLE
New duration calculator utility

### DIFF
--- a/src/main/java/io/wisetime/connector/testutils/FakeEntities.java
+++ b/src/main/java/io/wisetime/connector/testutils/FakeEntities.java
@@ -43,6 +43,10 @@ public class FakeEntities {
         .durationSplitStrategy(randomEnum(TimeGroup.DurationSplitStrategyEnum.class));
   }
 
+  public Tag randomTag() {
+    return randomTag(format("/{}/", FAKER.lorem().word()));
+  }
+
   public Tag randomTag(final String path) {
     return new Tag()
         .path(path)

--- a/src/main/java/io/wisetime/connector/utils/ActivityTimeCalculator.java
+++ b/src/main/java/io/wisetime/connector/utils/ActivityTimeCalculator.java
@@ -13,12 +13,20 @@ import io.wisetime.generated.connect.TimeGroup;
 import io.wisetime.generated.connect.TimeRow;
 
 /**
+ * Utility to calculate activity times relevant to WiseTime.
+ *
  * @author shane.xie@practiceinsight.io
  */
 public class ActivityTimeCalculator {
 
   private static final DateTimeFormatter ACTIVITY_HOUR_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHH");
 
+  /**
+   * The start time of a TimeGroup is the start of the segment hour of the earliest TimeRow in the group.
+   *
+   * @param timeGroup the TimeGroup whose start time to calculate
+   * @return start time without timezone information
+   */
   public static Optional<LocalDateTime> startTime(final TimeGroup timeGroup) {
     return timeGroup
         .getTimeRows()

--- a/src/main/java/io/wisetime/connector/utils/DurationCalculator.java
+++ b/src/main/java/io/wisetime/connector/utils/DurationCalculator.java
@@ -17,7 +17,7 @@ import io.wisetime.generated.connect.TimeRow;
 public class DurationCalculator {
 
   private TimeGroup timeGroup;
-  private DurationFrom durationFrom = DurationFrom.TIME_GROUP;
+  private DurationSource durationSource = DurationSource.TIME_GROUP;
   private boolean useExperienceRating = true;
 
   /**
@@ -27,7 +27,7 @@ public class DurationCalculator {
    * @return a DurationCalculator with the default configuration equivalent to:
    *
    *   DurationCalculator.of(timeGroup)
-   *       .useDurationFrom(DurationFrom.TIME_GROUP)
+   *       .useDurationFrom(DurationSource.TIME_GROUP)
    *       .useExperienceRating()
    */
   public static DurationCalculator of(final TimeGroup timeGroup) {
@@ -41,11 +41,11 @@ public class DurationCalculator {
   /**
    * Tell the calculator whether to read the duration from the TimeGroup or its TimeRows.
    *
-   * @param durationFrom which DurationFrom option to use
+   * @param durationSource which DurationSource option to use
    * @return the DurationCalculator with the duration from option applied
    */
-  public DurationCalculator useDurationFrom(final DurationFrom durationFrom) {
-    this.durationFrom = durationFrom;
+  public DurationCalculator useDurationFrom(final DurationSource durationSource) {
+    this.durationSource = durationSource;
     return this;
   }
 
@@ -77,16 +77,11 @@ public class DurationCalculator {
   public Result calculate() {
     final double totalDuration = sourceTotalDuration
         .andThen(applyExperienceRating)
-        .apply(durationFrom);
+        .apply(durationSource);
 
     final double perTagDuration = applyDurationSplitStrategy.apply(totalDuration);
 
     return new Result(Math.round(perTagDuration), Math.round(totalDuration));
-  }
-
-  public enum DurationFrom {
-    TIME_GROUP,
-    SUM_TIME_ROWS;
   }
 
   /**
@@ -121,14 +116,14 @@ public class DurationCalculator {
     }
   }
 
-  private final Function<DurationFrom, Double> sourceTotalDuration = durationFrom -> {
-    switch (durationFrom) {
+  private final Function<DurationSource, Double> sourceTotalDuration = durationSource -> {
+    switch (durationSource) {
       case TIME_GROUP:
         return timeGroup.getTotalDurationSecs().doubleValue();
       case SUM_TIME_ROWS:
         return timeGroup.getTimeRows().stream().mapToDouble(TimeRow::getDurationSecs).sum();
       default:
-        throw new IllegalStateException("Unhandled DurationFrom option");
+        throw new IllegalStateException("Unhandled DurationSource option");
     }
   };
 

--- a/src/main/java/io/wisetime/connector/utils/DurationCalculator.java
+++ b/src/main/java/io/wisetime/connector/utils/DurationCalculator.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2018 Practice Insight Pty Ltd. All Rights Reserved.
+ */
+
+package io.wisetime.connector.utils;
+
+import java.util.function.Function;
+
+import io.wisetime.generated.connect.TimeGroup;
+import io.wisetime.generated.connect.TimeRow;
+
+/**
+ * Utility to assist with calculating durations for a TimeGroup.
+ *
+ * @author shane.xie@practiceinsight.io
+ */
+public class DurationCalculator {
+
+  private TimeGroup timeGroup;
+  private DurationFrom durationFrom = DurationFrom.TIME_GROUP;
+  private boolean useExperienceRating = true;
+
+  /**
+   * Create a DurationCalculator for a TimeGroup.
+   *
+   * @param timeGroup the TimeGroup whose durations we want to calculate
+   * @return a DurationCalculator with the default configuration equivalent to:
+   *
+   *   DurationCalculator.of(timeGroup)
+   *       .useDurationFrom(DurationFrom.TIME_GROUP)
+   *       .useExperienceRating()
+   */
+  public static DurationCalculator of(final TimeGroup timeGroup) {
+    return new DurationCalculator(timeGroup);
+  }
+
+  private DurationCalculator(final TimeGroup timeGroup) {
+    this.timeGroup = timeGroup;
+  }
+
+  /**
+   * Tell the calculator whether to read the duration from the TimeGroup or its TimeRows.
+   *
+   * @param durationFrom which DurationFrom option to use
+   * @return the DurationCalculator with the duration from option applied
+   */
+  public DurationCalculator useDurationFrom(final DurationFrom durationFrom) {
+    this.durationFrom = durationFrom;
+    return this;
+  }
+
+  /**
+   * Tell the calculator to use the user's experience rating in its calculations.
+   *
+   * @return the DurationCalculator configured to use the user's experience rating
+   */
+  public DurationCalculator useExperienceRating() {
+    useExperienceRating = true;
+    return this;
+  }
+
+  /**
+   * Tell the calculator to disregard the user's experience rating in its calculations.
+   *
+   * @return the DurationCalculator configured to ignore the user's experience rating
+   */
+  public DurationCalculator disregardExperienceRating() {
+    useExperienceRating = false;
+    return this;
+  }
+
+  /**
+   * Calculate durations for the TimeGroup.
+   *
+   * @return Result containing the calculated per-tag and total durations
+   */
+  public Result calculate() {
+    final double totalDuration = sourceTotalDuration
+        .andThen(applyExperienceRating)
+        .apply(durationFrom);
+
+    final double perTagDuration = applyDurationSplitStrategy.apply(totalDuration);
+
+    return new Result(Math.round(perTagDuration), Math.round(totalDuration));
+  }
+
+  public enum DurationFrom {
+    TIME_GROUP,
+    SUM_TIME_ROWS;
+  }
+
+  /**
+   * The result of running DurationCalculator#calculate
+   */
+  public static class Result {
+
+    private long perTagDuration;
+    private long totalDuration;
+
+    private Result(final long perTagDuration, final long totalDuration) {
+      this.perTagDuration = perTagDuration;
+      this.totalDuration = totalDuration;
+    }
+
+    /**
+     * Get the calculated per-tag duration for the TimeGroup
+     *
+     * @return per-tag duration in seconds
+     */
+    public long getPerTagDuration() {
+      return perTagDuration;
+    }
+
+    /**
+     * Get the calculated total duration for the TimeGroup
+     *
+     * @return total duration in seconds
+     */
+    public long getTotalDuration() {
+      return totalDuration;
+    }
+  }
+
+  private final Function<DurationFrom, Double> sourceTotalDuration = durationFrom -> {
+    switch (durationFrom) {
+      case TIME_GROUP:
+        return timeGroup.getTotalDurationSecs().doubleValue();
+      case SUM_TIME_ROWS:
+        return timeGroup.getTimeRows().stream().mapToDouble(TimeRow::getDurationSecs).sum();
+      default:
+        throw new IllegalStateException("Unhandled DurationFrom option");
+    }
+  };
+
+  private final Function<Double, Double> applyExperienceRating = duration -> {
+    if (useExperienceRating) {
+      return duration * timeGroup.getUser().getExperienceWeightingPercent() / 100;
+    }
+    return duration;
+  };
+
+  private final Function<Double, Double> applyDurationSplitStrategy = duration -> {
+    switch (timeGroup.getDurationSplitStrategy()) {
+      case DIVIDE_BETWEEN_TAGS:
+        return duration / timeGroup.getTags().size();
+      case WHOLE_DURATION_TO_EACH_TAG:
+        return duration;
+      default:
+        throw new IllegalStateException("Unhandled DurationSplitStrategy option");
+    }
+  };
+}

--- a/src/main/java/io/wisetime/connector/utils/DurationSource.java
+++ b/src/main/java/io/wisetime/connector/utils/DurationSource.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2018 Practice Insight Pty Ltd. All Rights Reserved.
+ */
+
+package io.wisetime.connector.utils;
+
+/**
+ * Whether to read duration from a TimeGroup or the sum of its TimeRow durations.
+ *
+ * @author shane.xie@practiceinsight.io
+ */
+public enum DurationSource {
+  TIME_GROUP,
+  SUM_TIME_ROWS
+}

--- a/src/main/java/io/wisetime/connector/utils/TagDurationCalculator.java
+++ b/src/main/java/io/wisetime/connector/utils/TagDurationCalculator.java
@@ -7,8 +7,13 @@ package io.wisetime.connector.utils;
 import io.wisetime.generated.connect.TimeGroup;
 
 /**
+ * Utility to calculate Tag durations for a TimeGroup.
+ *
  * @author shane.xie@practiceinsight.io
+ *
+ * @deprecated use {@link DurationCalculator instead}
  */
+@Deprecated
 public class TagDurationCalculator {
 
   /**

--- a/src/test/java/io/wisetime/connector/utils/DurationCalculatorTest.java
+++ b/src/test/java/io/wisetime/connector/utils/DurationCalculatorTest.java
@@ -48,7 +48,7 @@ class DurationCalculatorTest {
     final DurationCalculator.Result result = DurationCalculator
         .of(timeGroup)
         .disregardExperienceRating()
-        .useDurationFrom(DurationCalculator.DurationFrom.TIME_GROUP)
+        .useDurationFrom(DurationSource.TIME_GROUP)
         .calculate();
 
     assertThat(result.getTotalDuration())
@@ -69,7 +69,7 @@ class DurationCalculatorTest {
     final DurationCalculator.Result result = DurationCalculator
         .of(timeGroup)
         .disregardExperienceRating()
-        .useDurationFrom(DurationCalculator.DurationFrom.SUM_TIME_ROWS)
+        .useDurationFrom(DurationSource.SUM_TIME_ROWS)
         .calculate();
 
     assertThat(result.getTotalDuration())
@@ -89,7 +89,7 @@ class DurationCalculatorTest {
     final DurationCalculator.Result result = DurationCalculator
         .of(timeGroup)
         .useExperienceRating()
-        .useDurationFrom(DurationCalculator.DurationFrom.TIME_GROUP)
+        .useDurationFrom(DurationSource.TIME_GROUP)
         .calculate();
 
     assertThat(result.getTotalDuration())
@@ -109,7 +109,7 @@ class DurationCalculatorTest {
     final DurationCalculator.Result result = DurationCalculator
         .of(timeGroup)
         .disregardExperienceRating()
-        .useDurationFrom(DurationCalculator.DurationFrom.TIME_GROUP)
+        .useDurationFrom(DurationSource.TIME_GROUP)
         .calculate();
 
     assertThat(result.getTotalDuration())
@@ -128,7 +128,7 @@ class DurationCalculatorTest {
     final DurationCalculator.Result result = DurationCalculator
         .of(timeGroup)
         .disregardExperienceRating()
-        .useDurationFrom(DurationCalculator.DurationFrom.TIME_GROUP)
+        .useDurationFrom(DurationSource.TIME_GROUP)
         .calculate();
 
     assertThat(result.getPerTagDuration())
@@ -147,7 +147,7 @@ class DurationCalculatorTest {
     final DurationCalculator.Result result = DurationCalculator
         .of(timeGroup)
         .disregardExperienceRating()
-        .useDurationFrom(DurationCalculator.DurationFrom.TIME_GROUP)
+        .useDurationFrom(DurationSource.TIME_GROUP)
         .calculate();
 
     assertThat(result.getPerTagDuration())

--- a/src/test/java/io/wisetime/connector/utils/DurationCalculatorTest.java
+++ b/src/test/java/io/wisetime/connector/utils/DurationCalculatorTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2018 Practice Insight Pty Ltd. All Rights Reserved.
+ */
+
+package io.wisetime.connector.utils;
+
+import com.google.common.collect.ImmutableList;
+
+import org.junit.jupiter.api.Test;
+
+import io.wisetime.connector.testutils.FakeEntities;
+import io.wisetime.generated.connect.TimeGroup;
+import io.wisetime.generated.connect.TimeRow;
+import io.wisetime.generated.connect.User;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author shane.xie@practiceinsight.io
+ */
+class DurationCalculatorTest {
+
+  private FakeEntities fakeEntities = new FakeEntities();
+
+  @Test
+  void config_defaultCalculator() {
+    final User user = fakeEntities.randomUser().experienceWeightingPercent(50);
+
+    final TimeGroup timeGroup = fakeEntities
+        .randomTimeGroup()
+        .totalDurationSecs(120)
+        .user(user);
+
+    final DurationCalculator.Result result = DurationCalculator.of(timeGroup).calculate();
+
+    assertThat(result.getTotalDuration())
+        .isEqualTo(60)
+        .as("Default calculator configuration should use the TimeGroup duration " +
+            "and apply the user's experience rating");
+  }
+
+  @Test
+  void config_useDurationFrom_timeGroup() {
+    final TimeGroup timeGroup = fakeEntities
+        .randomTimeGroup()
+        .totalDurationSecs(120);
+
+    final DurationCalculator.Result result = DurationCalculator
+        .of(timeGroup)
+        .disregardExperienceRating()
+        .useDurationFrom(DurationCalculator.DurationFrom.TIME_GROUP)
+        .calculate();
+
+    assertThat(result.getTotalDuration())
+        .isEqualTo(120)
+        .as("Duration should be taken from the time group");
+  }
+
+  @Test
+  void config_useDurationFrom_timeRows() {
+    final TimeRow timeRow1 = fakeEntities.randomTimeRow().durationSecs(70);
+    final TimeRow timeRow2 = fakeEntities.randomTimeRow().durationSecs(80);
+
+    final TimeGroup timeGroup = fakeEntities
+        .randomTimeGroup()
+        .totalDurationSecs(0)
+        .timeRows(ImmutableList.of(timeRow1, timeRow2));
+
+    final DurationCalculator.Result result = DurationCalculator
+        .of(timeGroup)
+        .disregardExperienceRating()
+        .useDurationFrom(DurationCalculator.DurationFrom.SUM_TIME_ROWS)
+        .calculate();
+
+    assertThat(result.getTotalDuration())
+        .isEqualTo(150)
+        .as("Duration should be taken from the time rows");
+  }
+
+  @Test
+  void config_useExperienceRating() {
+    final User user = fakeEntities.randomUser().experienceWeightingPercent(50);
+
+    final TimeGroup timeGroup = fakeEntities
+        .randomTimeGroup()
+        .totalDurationSecs(120)
+        .user(user);
+
+    final DurationCalculator.Result result = DurationCalculator
+        .of(timeGroup)
+        .useExperienceRating()
+        .useDurationFrom(DurationCalculator.DurationFrom.TIME_GROUP)
+        .calculate();
+
+    assertThat(result.getTotalDuration())
+        .isEqualTo(60)
+        .as("The user's experience rating should be taken into account");
+  }
+
+  @Test
+  void config_disregardExperienceRating() {
+    final User user = fakeEntities.randomUser().experienceWeightingPercent(50);
+
+    final TimeGroup timeGroup = fakeEntities
+        .randomTimeGroup()
+        .totalDurationSecs(120)
+        .user(user);
+
+    final DurationCalculator.Result result = DurationCalculator
+        .of(timeGroup)
+        .disregardExperienceRating()
+        .useDurationFrom(DurationCalculator.DurationFrom.TIME_GROUP)
+        .calculate();
+
+    assertThat(result.getTotalDuration())
+        .isEqualTo(120)
+        .as("The user's experience rating should be ignored");
+  }
+
+  @Test
+  void calculate_durationSplitStrategy_divideBetweenTags() {
+    final TimeGroup timeGroup = fakeEntities
+        .randomTimeGroup()
+        .totalDurationSecs(200)
+        .tags(ImmutableList.of(fakeEntities.randomTag(), fakeEntities.randomTag()))
+        .durationSplitStrategy(TimeGroup.DurationSplitStrategyEnum.DIVIDE_BETWEEN_TAGS);
+
+    final DurationCalculator.Result result = DurationCalculator
+        .of(timeGroup)
+        .disregardExperienceRating()
+        .useDurationFrom(DurationCalculator.DurationFrom.TIME_GROUP)
+        .calculate();
+
+    assertThat(result.getPerTagDuration())
+        .isEqualTo(100)
+        .as("Duration split between the two tags");
+  }
+
+  @Test
+  void calculate_durationSplitStrategy_wholeDurationToEachTag() {
+    final TimeGroup timeGroup = fakeEntities
+        .randomTimeGroup()
+        .totalDurationSecs(200)
+        .tags(ImmutableList.of(fakeEntities.randomTag(), fakeEntities.randomTag()))
+        .durationSplitStrategy(TimeGroup.DurationSplitStrategyEnum.WHOLE_DURATION_TO_EACH_TAG);
+
+    final DurationCalculator.Result result = DurationCalculator
+        .of(timeGroup)
+        .disregardExperienceRating()
+        .useDurationFrom(DurationCalculator.DurationFrom.TIME_GROUP)
+        .calculate();
+
+    assertThat(result.getPerTagDuration())
+        .isEqualTo(200)
+        .as("Whole duration should be applied to each tags");
+  }
+}


### PR DESCRIPTION
New `DurationCalculator` utility class that supports Patricia use cases. Use fluent API for configuring calculator, then run calculation at the end. Deprecates old `TagDurationCalculator`.