### PR TITLE
Add support for batch keyword additions to tags

### DIFF
--- a/src/main/java/io/wisetime/connector/api_client/ApiClient.java
+++ b/src/main/java/io/wisetime/connector/api_client/ApiClient.java
@@ -6,8 +6,9 @@ package io.wisetime.connector.api_client;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
-import io.wisetime.generated.connect.AddKeywordsRequest;
 import io.wisetime.generated.connect.SubscribeRequest;
 import io.wisetime.generated.connect.SubscribeResult;
 import io.wisetime.generated.connect.TeamInfoResult;
@@ -45,13 +46,21 @@ public interface ApiClient {
   void tagDelete(String tagName) throws IOException;
 
   /**
-   * Add keywords to a tag. Existing keywords not be overwritten.
+   * Add keywords to a tag. Existing keywords will not be overwritten.
    *
    * @param tagName the tag to which to add the keywords
-   * @param addKeywordsRequest request contains list of keywords to be added
+   * @param additionalKeywords set of new keyword Strings to add to the tag
    * @throws IOException
    */
-  void tagAddKeywords(String tagName, AddKeywordsRequest addKeywordsRequest) throws IOException;
+  void tagAddKeywords(String tagName, Set<String> additionalKeywords) throws IOException;
+
+  /**
+   * Add keywords to a batch of tags. Existing keywords will not be overwritten.
+   *
+   * @param tagNamesAndAdditionalKeywords a map of tag names and set of keywords to add to each tag
+   * @throws IOException
+   */
+  void tagAddKeywordsBatch(Map<String, Set<String>> tagNamesAndAdditionalKeywords) throws IOException;
 
   /**
    * Delete keyword from a tag.

--- a/src/test/java/io/wisetime/connector/api_client/DefaultApiClientIntegrationTest.java
+++ b/src/test/java/io/wisetime/connector/api_client/DefaultApiClientIntegrationTest.java
@@ -4,7 +4,7 @@
 
 package io.wisetime.connector.api_client;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 
 import org.junit.jupiter.api.BeforeAll;
@@ -18,7 +18,6 @@ import java.util.Optional;
 import io.wisetime.connector.api_client.support.RestRequestExecutor;
 import io.wisetime.connector.config.ConnectorConfigKey;
 import io.wisetime.connector.config.RuntimeConfig;
-import io.wisetime.generated.connect.AddKeywordsRequest;
 import io.wisetime.generated.connect.SubscribeRequest;
 import io.wisetime.generated.connect.SubscribeResult;
 import io.wisetime.generated.connect.TeamInfoResult;
@@ -102,9 +101,7 @@ class DefaultApiClientIntegrationTest {
     if (defaultApiClient == null) {
       return;
     }
-    AddKeywordsRequest request = new AddKeywordsRequest();
-    request.setAdditionalKeywords(ImmutableList.of("keyword_from_API", "keyword with space"));
-    defaultApiClient.tagAddKeywords("CreatedViaApi", request);
+    defaultApiClient.tagAddKeywords("CreatedViaApi", ImmutableSet.of("keyword_from_API", "keyword with space"));
   }
 
   @Test

--- a/src/test/java/io/wisetime/connector/api_client/DefaultApiClientTest.java
+++ b/src/test/java/io/wisetime/connector/api_client/DefaultApiClientTest.java
@@ -4,15 +4,22 @@
 
 package io.wisetime.connector.api_client;
 
+import com.google.common.collect.ImmutableSet;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.IntStream;
 
 import io.wisetime.connector.api_client.support.RestRequestExecutor;
+import io.wisetime.generated.connect.AddKeywordsRequest;
+import io.wisetime.generated.connect.AddKeywordsResponse;
 import io.wisetime.generated.connect.UpsertTagRequest;
 import io.wisetime.generated.connect.UpsertTagResponse;
 
@@ -63,8 +70,8 @@ public class DefaultApiClientTest {
         apiClient.tagUpsertBatch(fakeUpsertTagRequests(1000))
     );
 
-    // At least 10 requests made in parallel before we notice an error.
-    verify(requestExecutor, atLeast(10)).executeTypedBodyRequest(
+    // Requests are made in parallel before we notice an error.
+    verify(requestExecutor, atLeast(9)).executeTypedBodyRequest(
         any(),
         any(EndpointPath.TagUpsert.getClass()),
         any(UpsertTagRequest.class)
@@ -88,11 +95,71 @@ public class DefaultApiClientTest {
     );
   }
 
+  @Test
+  void tagAddKeywordsBatch_completes_on_no_error() throws IOException {
+    when(requestExecutor.executeTypedBodyRequest(any(), any(), any(), any()))
+        .thenReturn(new AddKeywordsResponse());
+
+    apiClient.tagAddKeywordsBatch(fakeTagNamesAndAdditionalKeywords(5));
+
+    verify(requestExecutor, times(5)).executeTypedBodyRequest(
+        any(),
+        any(EndpointPath.TagAddKeyword.getClass()),
+        any(List.class),
+        any(AddKeywordsRequest.class)
+    );
+  }
+
+  @Test
+  void tagAddKeywordsBatch_stops_on_error() throws IOException {
+    when(requestExecutor.executeTypedBodyRequest(any(), any(), any(), any()))
+        .thenReturn(new AddKeywordsResponse())
+        .thenThrow(new IOException());
+
+    assertThatExceptionOfType(IOException.class).isThrownBy(() ->
+        apiClient.tagAddKeywordsBatch(fakeTagNamesAndAdditionalKeywords(1000))
+    );
+
+    // Requests are made in parallel before we notice an error.
+    verify(requestExecutor, atLeast(9)).executeTypedBodyRequest(
+        any(),
+        any(EndpointPath.TagAddKeyword.getClass()),
+        any(List.class),
+        any(AddKeywordsRequest.class)
+    );
+
+    // We should notice that a request has failed way before we reach the end of the list
+    verify(requestExecutor, atMost(20)).executeTypedBodyRequest(
+        any(),
+        any(EndpointPath.TagAddKeyword.getClass()),
+        any(List.class),
+        any(AddKeywordsRequest.class)
+    );
+  }
+
+  @Test
+  void tagAddKeywordsBatch_wraps_exceptions() throws IOException {
+    when(requestExecutor.executeTypedBodyRequest(any(), any(), any(), any()))
+        .thenThrow(new RuntimeException());
+
+    assertThatExceptionOfType(IOException.class).isThrownBy(() ->
+        apiClient.tagAddKeywordsBatch(fakeTagNamesAndAdditionalKeywords(3))
+    );
+  }
+
   private List<UpsertTagRequest> fakeUpsertTagRequests(final int numberOfRequests) {
     final ArrayList<UpsertTagRequest> requests = new ArrayList<>();
     IntStream
         .range(1, numberOfRequests + 1)
         .forEach(i -> requests.add(new UpsertTagRequest().name(String.valueOf(i))));
     return requests;
+  }
+
+  private Map<String, Set<String>> fakeTagNamesAndAdditionalKeywords(final int numberOfTags) {
+    final Map<String, Set<String>> tagsAndKeywords = new HashMap<>();
+    IntStream
+        .range(1, numberOfTags + 1)
+        .forEach(i -> tagsAndKeywords.put(String.valueOf(i), ImmutableSet.of(String.valueOf(i))));
+    return tagsAndKeywords;
   }
 }


### PR DESCRIPTION
* Remove redundant wrapping into request when adding keywords to a tag. This changes the public API.
* Add support for batch keyword additions to tags